### PR TITLE
Add compiler pass to automatically register entity repositories into the...

### DIFF
--- a/spec/Knp/RadBundle/DependencyInjection/Compiler/RegisterDoctrineRepositoriesPass.php
+++ b/spec/Knp/RadBundle/DependencyInjection/Compiler/RegisterDoctrineRepositoriesPass.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace spec\Knp\RadBundle\DependencyInjection\Compiler;
+
+use PHPSpec2\ObjectBehavior;
+
+class RegisterDoctrineRepositoriesPass extends ObjectBehavior
+{
+    /**
+     * @param Symfony\Component\HttpKernel\Bundle\BundleInterface $bundle
+     * @param Symfony\Component\DependencyInjection\ContainerBuilder $container
+     * @param Knp\RadBundle\Finder\ClassFinder $classFinder
+     * @param Knp\RadBundle\DependencyInjection\Compiler\RepositoryDefinitionFactory $definitionFactory
+     */
+    function let($bundle, $container, $classFinder, $definitionFactory)
+    {
+        $this->beConstructedWith($bundle, $classFinder, $definitionFactory);
+    }
+
+    function it_should_be_a_compiler_pass()
+    {
+        $this->shouldBeAnInstanceOf('Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface');
+    }
+
+    /**
+     * @param Symfony\Component\DependencyInjection\Definition $cheeseDef
+     * @param Symfony\Component\DependencyInjection\Definition $customerDef
+     */
+    function it_should_register_a_repository_service_for_all_entities_found_in_the_bundle($container, $bundle, $classFinder, $definitionFactory, $cheeseDef, $customerDef)
+    {
+        $bundle->getPath()->shouldBeCalled()->willReturn('/my/project/src/App');
+        $bundle->getNamespace()->shouldBeCalled()->willReturn('App');
+
+        $classFinder->findClassesMatching('/my/project/src/App/Entity', 'App\Entity', '(?<!Repository)$')->shouldBeCalled()->willReturn(array('App\Entity\Cheese', 'App\Entity\Customer'));
+
+        $definitionFactory->createDefinition('App\Entity\Cheese')->shouldBeCalled()->willReturn($cheeseDef);
+        $definitionFactory->createDefinition('App\Entity\Customer')->shouldBeCalled()->willReturn($customerDef);
+
+        $container->setDefinition('orm.cheese_repository', $cheeseDef)->shouldBeCalled();
+        $container->setDefinition('orm.customer_repository', $customerDef)->shouldBeCalled();
+
+        $this->process($container);
+    }
+
+    /**
+     * @param Symfony\Component\DependencyInjection\Definition $definition
+     */
+    function it_should_underscore_camelcased_names($container, $bundle, $classFinder, $definitionFactory, $definition)
+    {
+        $bundle->getPath()->shouldBeCalled()->willReturn('/my/project/src/App');
+        $bundle->getNamespace()->shouldBeCalled()->willReturn('App');
+
+        $classFinder->findClassesMatching('/my/project/src/App/Entity', 'App\Entity', '(?<!Repository)$')->shouldBeCalled()->willReturn(array('App\Entity\CheesePicture'));
+
+        $definitionFactory->createDefinition('App\Entity\CheesePicture')->shouldBeCalled()->willReturn($definition);
+
+        $container->setDefinition('orm.cheese_picture_repository', $definition)->shouldBeCalled();
+
+        $this->process($container);
+    }
+
+    /**
+     * @param Symfony\Component\DependencyInjection\Definition $definition
+     */
+    function it_should_replace_namespace_separatores_by_dots_in_names($container, $bundle, $classFinder, $definitionFactory, $definition)
+    {
+        $bundle->getPath()->shouldBeCalled()->willReturn('/my/project/src/App');
+        $bundle->getNamespace()->shouldBeCalled()->willReturn('App');
+
+        $classFinder->findClassesMatching('/my/project/src/App/Entity', 'App\Entity', '(?<!Repository)$')->shouldBeCalled()->willReturn(array('App\Entity\Cheese\Picture'));
+
+        $definitionFactory->createDefinition('App\Entity\Cheese\Picture')->shouldBeCalled()->willReturn($definition);
+
+        $container->setDefinition('orm.cheese.picture_repository', $definition)->shouldBeCalled();
+
+        $this->process($container);
+    }
+}

--- a/spec/Knp/RadBundle/DependencyInjection/Compiler/RepositoryDefinitionFactory.php
+++ b/spec/Knp/RadBundle/DependencyInjection/Compiler/RepositoryDefinitionFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace spec\Knp\RadBundle\DependencyInjection\Compiler;
+
+use PHPSpec2\ObjectBehavior;
+
+class RepositoryDefinitionFactory extends ObjectBehavior
+{
+    function it_should_create_repository_definition_for_the_given_classe_name()
+    {
+        $definition = $this->createDefinition('App\Entity\Cheese');
+        $definition->shouldBeAnInstanceOf('Symfony\Component\DependencyInjection\Definition');
+
+        $definition->getFactoryService()->shouldReturn('doctrine');
+        $definition->getFactoryMethod()->shouldReturn('getRepository');
+        $definition->getArguments()->shouldReturn(array('App\Entity\Cheese'));
+        $definition->isPublic()->shouldReturn(false);
+    }
+}

--- a/spec/Knp/RadBundle/Finder/ClassFinder.php
+++ b/spec/Knp/RadBundle/Finder/ClassFinder.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace spec\Knp\RadBundle\Finder;
+
+use PHPSpec2\ObjectBehavior;
+use Symfony\Component\Filesystem\Filesystem;
+
+class ClassFinder extends ObjectBehavior
+{
+    /**
+     * @param  Symfony\Component\Finder\Finder $finder
+     */
+    function let($finder)
+    {
+        $this->beConstructedWith($finder);
+
+        $finder->name('*.php')->shouldBeCalled();
+        $finder->in('/my/project/src/App/Entity')->shouldBeCalled();
+        $finder->getIterator()->shouldBeCalled()->willReturn(array(
+            '/my/project/src/App/Entity/Cheese.php',
+            '/my/project/src/App/Entity/CheeseRepository.php',
+            '/my/project/src/App/Entity/Customer.php',
+            '/my/project/src/App/Entity/CustomerRepository.php',
+            '/my/project/src/App/Entity/Customer/Address.php',
+        ));
+    }
+
+    function it_should_find_classes_from_specified_the_namespace_directory($finder)
+    {
+        $this->findClasses('/my/project/src/App/Entity', 'App\Entity')->shouldReturn(array(
+            'App\Entity\Cheese',
+            'App\Entity\CheeseRepository',
+            'App\Entity\Customer',
+            'App\Entity\CustomerRepository',
+            'App\Entity\Customer\Address',
+        ));
+    }
+
+    function it_should_allow_to_filter_by_name_pattern($finder)
+    {
+        $this->findClassesMatching('/my/project/src/App/Entity', 'App\Entity', '(?<!Repository)$')->shouldReturn(array(
+            'App\Entity\Cheese',
+            'App\Entity\Customer',
+            'App\Entity\Customer\Address',
+        ));
+    }
+}

--- a/src/Knp/RadBundle/AppBundle/Bundle.php
+++ b/src/Knp/RadBundle/AppBundle/Bundle.php
@@ -3,9 +3,16 @@
 namespace Knp\RadBundle\AppBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle as BaseBundle;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Knp\RadBundle\DependencyInjection\Compiler\RegisterDoctrineRepositoriesPass;
 
 class Bundle extends BaseBundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new RegisterDoctrineRepositoriesPass($this));
+    }
+
     public function getContainerExtension()
     {
         if ($extension = parent::getContainerExtension()) {

--- a/src/Knp/RadBundle/DependencyInjection/Compiler/RegisterDoctrineRepositoriesPass.php
+++ b/src/Knp/RadBundle/DependencyInjection/Compiler/RegisterDoctrineRepositoriesPass.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Knp\RadBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Knp\RadBundle\Finder\ClassFinder;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Symfony\Component\DependencyInjection\Container;
+
+class RegisterDoctrineRepositoriesPass implements CompilerPassInterface
+{
+    private $bundle;
+    private $classFinder;
+    private $definitionFactory;
+
+    public function __construct(BundleInterface $bundle, ClassFinder $classFinder = null, RepositoryDefinitionFactory $definitionFactory = null)
+    {
+        $this->bundle = $bundle;
+        $this->classFinder = $classFinder ?: new ClassFinder();
+        $this->definitionFactory = $definitionFactory ?: new RepositoryDefinitionFactory();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $directory = $this->bundle->getPath().'/Entity';
+        $namespace = $this->bundle->getNamespace().'\Entity';
+
+        $classes = $this->classFinder->findClassesMatching($directory, $namespace, '(?<!Repository)$');
+
+        foreach ($classes as $class) {
+            $baseClass = substr($class, strlen($namespace) + 1);
+
+            $id = sprintf('orm.%s_repository', str_replace('\\', '.', Container::underscore($baseClass)));
+            $def = $this->definitionFactory->createDefinition($class);
+
+            $container->setDefinition($id, $def);
+        }
+    }
+}

--- a/src/Knp/RadBundle/DependencyInjection/Compiler/RepositoryDefinitionFactory.php
+++ b/src/Knp/RadBundle/DependencyInjection/Compiler/RepositoryDefinitionFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Knp\RadBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Definition;
+
+class RepositoryDefinitionFactory
+{
+    public function createDefinition($className)
+    {
+        $definition = new Definition();
+        $definition->setPublic(false);
+        $definition->setClass('Doctrine\Common\Persistence\ObjectRepository');
+        $definition->setFactoryService('doctrine');
+        $definition->setFactoryMethod('getRepository');
+        $definition->setArguments(array($className));
+
+        return $definition;
+    }
+}

--- a/src/Knp/RadBundle/Finder/ClassFinder.php
+++ b/src/Knp/RadBundle/Finder/ClassFinder.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Knp\RadBundle\Finder;
+
+use Symfony\Component\Finder\Finder;
+
+class ClassFinder
+{
+    private $finder;
+
+    public function __construct(Finder $finder = null)
+    {
+        $this->finder = $finder ?: new Finder();
+    }
+
+    public function findClasses($directory, $namespace)
+    {
+        $classes = array();
+
+        $this->finder->files();
+        $this->finder->name('*.php');
+        $this->finder->in($directory);
+
+        foreach ($this->finder->getIterator() as $name) {
+            $baseName = substr($name, strlen($directory)+1, -4);
+            $baseClassName = str_replace('/', '\\', $baseName);
+
+            $classes[] = $namespace.'\\'.$baseClassName;
+        }
+
+        return $classes;
+    }
+
+    public function findClassesMatching($directory, $namespace, $pattern)
+    {
+        $pattern = sprintf('#%s#', str_replace('#', '\#', $pattern));
+        $matches = function ($path) use ($pattern) { return preg_match($pattern, $path); };
+
+        return array_values(array_filter($this->findClasses($directory, $namespace), $matches));
+    }
+}


### PR DESCRIPTION
It registers a service into the DIC for the repository of every entity class found in the bundle.

If your project contains the following files,

```
src/
└── App
    └── Entity
        ├── Cheese.php
        ├── CheesePicture.php
        ├── CheeseRepository.php
        ├── Customer
        │   └── Address.php
        ├── Customer.php
        └── CustomerRepository.php
```

it will register 4 services:
- orm.cheese_repository
- orm.cheese_picture_repository
- orm.customer_repository
- orm.customer.address_repository

The services are defined as private.
