### PR TITLE
Fix directory creation by view assistant creator

### DIFF
--- a/src/Knp/RadBundle/Controller/AssistantController.php
+++ b/src/Knp/RadBundle/Controller/AssistantController.php
@@ -34,7 +34,7 @@ class AssistantController extends Controller
         $viewPath = $this->get('knp_rad.view.path_deducer')->deducePath($viewName);
 
         // in case directory does not exist
-        $this->get('filesystem')->touch($viewPath);
+        $this->get('filesystem')->mkdir(dirname($viewPath));
 
         file_put_contents($viewPath, $viewBody);
 


### PR DESCRIPTION
`touch()` used to return `Cannot touch [...]/App/Ressources/view/Entity/index.html.twig`.
`mkdir()` fixes it.
